### PR TITLE
Add tests for login form

### DIFF
--- a/src/common/components/page-loader.tsx
+++ b/src/common/components/page-loader.tsx
@@ -1,22 +1,23 @@
-import { Text, Box, Spinner, VStack } from "@chakra-ui/react"
-import { FC } from "react";
+import { Text, Box, Spinner, VStack } from '@chakra-ui/react'
+import React, { FC } from 'react'
 
 const PageLoader: FC = () => {
   return (
     <Box className="loader_blur">
-        <VStack>
-          <Text fontSize="xl" mt="45vh" >Loading...</Text>
-          <Spinner
-            thickness="4px"
-            speed="0.65s"
-            emptyColor="gray.200"
-            color="teal"
-            size="xl"
-          />
-        </VStack>
+      <VStack>
+        <Text fontSize="xl" mt="45vh">
+          Loading...
+        </Text>
+        <Spinner
+          thickness="4px"
+          speed="0.65s"
+          emptyColor="gray.200"
+          color="teal"
+          size="xl"
+        />
+      </VStack>
     </Box>
-
-  );
+  )
 }
 
 export default PageLoader

--- a/src/common/data/auth.tsx
+++ b/src/common/data/auth.tsx
@@ -52,7 +52,10 @@ interface LoginInput {
  */
 
 // ANCHOR Describe query
-export const query: TypedDocumentNode<CurrentUserData, undefined> = gql`
+export const query: TypedDocumentNode<
+  CurrentUserData,
+  Record<string, never>
+> = gql`
   query CurrentUserQuery {
     currentUser {
       _id
@@ -88,7 +91,10 @@ export const loginQuery: TypedDocumentNode<LoginData, LoginInput> = gql`
 `
 
 // ANCHOR Describe logout query
-export const logoutQuery: TypedDocumentNode<LogoutData> = gql`
+export const logoutQuery: TypedDocumentNode<
+  LogoutData,
+  Record<string, never>
+> = gql`
   mutation LogoutUser {
     logoutUser
   }
@@ -158,8 +164,8 @@ export const AuthContextProvider: FC = ({ children }) => {
           },
         })
       },
-      onCompleted: (data) => {
-        usersService.set(data.signupUser.secret, data.signupUser.instance)
+      onCompleted: async (data) => {
+        await usersService.set(data.signupUser.secret, data.signupUser.instance)
         faunaTokenManager.set(data.signupUser.secret)
       },
     })

--- a/src/common/state/users.ts
+++ b/src/common/state/users.ts
@@ -15,12 +15,15 @@ export class UsersQuery extends Query<UsersState> {
   }
 }
 
-export const userQuery = new UsersQuery(new UsersStore())
-
 export class UsersService {
-  constructor(private usersStore: UsersStore) {}
+  private usersQuery: UsersQuery
 
-  get = (token: string): User | undefined => userQuery.getValue()[token]
+  constructor(private usersStore: UsersStore) {
+    this.usersQuery = new UsersQuery(usersStore)
+  }
+
+  getAll = (): UsersState => this.usersQuery.getValue()
+  get = (token: string): User | undefined => this.usersQuery.getValue()[token]
 
   set = (token: string, user: User): void => {
     this.usersStore.update((state) => ({ ...state, [token]: user }))
@@ -38,7 +41,7 @@ export class UsersService {
     })
   }
 
-  resest = (): void => {
+  reset = (): void => {
     this.usersStore.update({})
   }
 }

--- a/test/common/components/__snapshots__/login-form-render.spec.tsx.snap
+++ b/test/common/components/__snapshots__/login-form-render.spec.tsx.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Login form should render correctly 1`] = `
+<form
+  onSubmit={[Function]}
+>
+  <div
+    className="chakra-form-control css-1kxonj9"
+    role="group"
+  >
+    <label
+      className="chakra-form__label css-uvho5g"
+      htmlFor="field-1"
+      id="field-1-label"
+    >
+      Username
+      <input
+        className="chakra-input css-0"
+        disabled={false}
+        id="field-1"
+        name="username"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        readOnly={false}
+        required={false}
+        type="text"
+      />
+    </label>
+    <label
+      className="chakra-form__label css-uvho5g"
+      htmlFor="field-1"
+      id="field-1-label"
+    >
+      Password
+      <input
+        className="chakra-input css-0"
+        disabled={false}
+        id="field-1"
+        name="password"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        readOnly={false}
+        required={false}
+        type="password"
+      />
+    </label>
+    <div
+      className="css-gmuwbf"
+    >
+      <button
+        className="chakra-button css-1xx8uq7"
+        disabled={false}
+        onClick={[Function]}
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </div>
+</form>
+`;

--- a/test/common/components/login-form-render.spec.tsx
+++ b/test/common/components/login-form-render.spec.tsx
@@ -1,0 +1,30 @@
+import { InMemoryCache } from '@apollo/client'
+import React from 'react'
+import testRenderer from 'react-test-renderer'
+import { LoginForm } from '../../../src/common/components'
+import { TestAuth } from '../../utils/auth'
+
+/**
+ * SECTION Test suite
+ */
+describe('Login form', () => {
+  let cache: InMemoryCache
+
+  // ANCHOR Unit test - check for the component's HTML rendering
+  it('should render correctly', () => {
+    // Create a static render
+    const tree = testRenderer
+      .create(
+        <TestAuth cache={cache}>
+          <LoginForm
+            callback={async () => undefined}
+            mutationResult={{ loading: false, called: true }}
+          />
+        </TestAuth>
+      )
+      .toJSON()
+
+    // Check the static render against the snapshot
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/test/common/components/login-form.spec.tsx
+++ b/test/common/components/login-form.spec.tsx
@@ -1,0 +1,109 @@
+import { InMemoryCache } from '@apollo/client'
+import { act } from '@testing-library/react'
+import { mount } from 'enzyme'
+import React from 'react'
+import { LoginForm } from '../../../src/common/components'
+import { query, useAuthContext } from '../../../src/common/data/auth'
+import usersService from '../../../src/common/state/users'
+import { FaunaTokenManager } from '../../../src/common/utils'
+import { TestAuth, user } from '../../utils/auth'
+
+// This function forces tests to wait for hooks to resolve
+const waitForResponse = (): Promise<void> =>
+  new Promise((res) => setTimeout(res, 0))
+
+const WrappedLoginForm = () => {
+  const { actions } = useAuthContext()
+  const [login, mutationResult] = actions.useLogin()
+
+  const callback = async (
+    username: string,
+    password: string
+  ): Promise<void> => {
+    try {
+      await login({ variables: { username, password } })
+      // eslint-disable-next-line no-empty
+    } catch (error) {}
+  }
+
+  return <LoginForm callback={callback} mutationResult={mutationResult} />
+}
+
+/**
+ * SECTION Test suite
+ */
+describe('Login form', () => {
+  let cache: InMemoryCache
+
+  // ANCHOR Operations to trigger before each test
+  beforeEach(() => {
+    // Reset memory cache
+    cache = new InMemoryCache({ addTypename: false })
+  })
+
+  // ANCHOR Functional test - check the component intially triggers a query that fills the cache
+  it('should find no logged user', async () => {
+    process.env.NEXT_PUBLIC_FAUNA_SECRET = 'public-token'
+
+    // Mount component in a virtual DOM
+    mount(
+      <TestAuth cache={cache}>
+        <WrappedLoginForm />
+      </TestAuth>
+    )
+
+    // Wait for hooks to resolve
+    await act(async () => {
+      await waitForResponse()
+    })
+
+    // Read result from the GraphQL query
+    const data = cache.readQuery({ query })
+    // The query result should be null
+    expect(data?.currentUser).toBeNull()
+    const tokenManager = new FaunaTokenManager()
+    const token = tokenManager.get()
+    expect(token).toEqual('public-token')
+    expect(typeof usersService.get(token)).toEqual('undefined')
+  })
+
+  // ANCHOR Functional test - check the component triggers a mutation that changes data in the cache
+  it('should populate the logged user in the cache when submitted', async () => {
+    process.env.NEXT_PUBLIC_FAUNA_SECRET = 'public-token'
+
+    const element = mount(
+      <TestAuth cache={cache}>
+        <WrappedLoginForm />
+      </TestAuth>
+    )
+
+    // Wait for hooks to resolve
+    await act(async () => {
+      await waitForResponse()
+      // Simulate a click on the button
+      element.find('input[name="username"]').simulate('change', {
+        target: {
+          value: 'test',
+        },
+      })
+      element.find('input[name="password"]').simulate('change', {
+        target: {
+          value: 'test',
+        },
+      })
+      element.simulate('submit')
+      // Wait for hooks to resolve again
+      await waitForResponse()
+    })
+
+    // Read result from the GraphQL query
+    const data = cache.readQuery({ query })
+    expect(data?.currentUser).not.toBeNull()
+    expect(data?.currentUser?._id).toEqual(user._id)
+    expect(data?.currentUser?.username).toEqual(user.username)
+    const tokenManager = new FaunaTokenManager()
+    const token = tokenManager.get()
+    expect(token).toEqual('authenticated-token')
+    expect(usersService.get(token)).toEqual(user)
+  })
+})

--- a/test/utils/all-tasks.tsx
+++ b/test/utils/all-tasks.tsx
@@ -114,12 +114,7 @@ export const TestAllTasks: FC<{ cache: InMemoryCache }> = ({
   cache,
   children,
 }) => (
-  <MockedProvider
-    cache={cache}
-    mocks={mocks}
-    addTypename={false}
-    // defaultOptions={{ watchQuery: { fetchPolicy: 'no-cache' } }}
-  >
+  <MockedProvider cache={cache} mocks={mocks} addTypename={false}>
     <AllTasksContextProvider currentUser={user} initialData={initialData}>
       {children}
     </AllTasksContextProvider>

--- a/test/utils/auth.tsx
+++ b/test/utils/auth.tsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import { InMemoryCache } from '@apollo/client'
+import { MockedProvider } from '@apollo/client/testing'
+import { FC } from 'react'
+import {
+  loginQuery,
+  logoutQuery,
+  query,
+  signupQuery,
+  AuthContextProvider,
+} from '../../src/common/data/auth'
+import { User } from '../../src/common/types/fauna'
+import { MockType } from './types'
+
+export const user: User = { _id: 'user0', _ts: 0, username: 'test' }
+
+const initialData = {
+  currentUser: null,
+}
+
+const queryMock: MockType<typeof query> = {
+  request: {
+    query,
+    variables: {},
+  },
+  result: {
+    data: initialData,
+  },
+}
+
+const signupQueryMock: MockType<typeof signupQuery> = {
+  request: {
+    query: signupQuery,
+    variables: { username: 'test', password: 'test' },
+  },
+  result: {
+    data: {
+      signupUser: {
+        secret: 'authenticated-token',
+        instance: user,
+      },
+    },
+  },
+}
+
+const loginQueryMock: MockType<typeof loginQuery> = {
+  request: {
+    query: loginQuery,
+    variables: { username: 'test', password: 'test' },
+  },
+  result: {
+    data: {
+      loginUser: {
+        secret: 'authenticated-token',
+        instance: user,
+      },
+    },
+  },
+}
+
+const logoutQueryMock: MockType<typeof logoutQuery> = {
+  request: {
+    query: logoutQuery,
+    variables: {},
+  },
+  result: {
+    data: {
+      logoutData: true,
+    },
+  },
+}
+
+const mocks = [queryMock, signupQueryMock, loginQueryMock, logoutQueryMock]
+
+export const TestAuth: FC<{ cache: InMemoryCache }> = ({ cache, children }) => (
+  <MockedProvider cache={cache} mocks={mocks} addTypename={false}>
+    <AuthContextProvider>{children}</AuthContextProvider>
+  </MockedProvider>
+)


### PR DESCRIPTION
Login form now has a test suite.

- The suite will test that the component matches snapshot
- The suite will test that no authenticated user is present in the Apollo cache when the component is mounted
- The suite will test that an authenticated user appears in the Apollo cache when the form is submitted
- The suite will test that the token manager and the Akita store react accordingly to these operations